### PR TITLE
Initial working commit

### DIFF
--- a/lua/includes/modules/callable_properties.lua
+++ b/lua/includes/modules/callable_properties.lua
@@ -1,0 +1,73 @@
+CallableProperties = {}
+
+local function setup(object)
+    local meta = getmetatable(object)
+
+    -- Handles situations where the metatabale's __index was already set
+    local originalIndex
+    if meta then
+        originalIndex = meta.__index
+    end
+
+    setmetatable(object, {
+        __callableProperties = {},
+        __originalIndex = originalIndex,
+        __index = function (self, index)
+            local meta = getmetatable(self)
+
+            local storedValue = meta.__callableProperties[index]
+            if storedValue then
+                if storedValue == nil then return end
+                if type(storedValue) ~= "function" then return storedValue end
+
+                return storedValue(object)
+            end
+
+            -- Super gross way to stop infinite recursion
+            local copyobj = table.Copy(object)
+            local copyMeta = table.Copy(getmetatable(copyobj))
+
+            -- Will either be what the index lookup was before we wrapped it or nil which results in default lookup
+            copyMeta.__index = copyMeta.__originalIndex
+
+            setmetatable(copyobj, copyMeta)
+
+            return copyobj[index]
+        end
+    })
+end
+
+local function teardown(object)
+    local meta = getmetatable(object)
+    meta.__index = meta.__originalIndex
+    meta.__originalIndex = nil
+    meta.__callableProperties = nil
+
+    setmetatable(object, meta)
+end
+
+function CallableProperties.register(object, key)
+    if key == "__index" then error("Cannot register __index") end
+
+    local meta = getmetatable(object)
+
+    if not meta then setup(object) end
+
+    meta = getmetatable(object)
+    meta.__callableProperties[key] = object[key]
+    setmetatable( object, meta )
+
+    object[key] = nil
+end
+
+function CallableProperties.deregister(object, key)
+    local meta = getmetatable(object)
+    if not meta.__callableProperties then return end
+
+    object[key] = meta.__callableProperties[key]
+    meta.__callableProperties[key] = nil
+
+    if table.Count(meta.__callableProperties) == 0 then return teardown(object) end
+
+    setmetatable(object, meta)
+end


### PR DESCRIPTION
While working on the Player PvP addon, I had the idea of being able to call functions on tables without actually having to _call_ them.

Here's what I mean:
```lua
local myTable = {
    isReady = function() return findOut() end
}

-- If you want to do a simple isReady check, it needs to be called as a function
myTable.isReady()

-- But what if we could access it as if it were a property and still get the desired result?
myTable.isReady
```

Look at that, two entire characters saved!
Just imagine all of the things you could do with those extra bytes.


Where I expect to see the most benefit is actually in Moonscript. This started when I was trying to set `isInPvp` on the Player metatable, but then I realized that it was kind of gross to call it like this
```moonscript
if ply\isInPvp!
```

I'd really like to be able to do this instead:
```moonscript
if ply.isInPvp
```
I think it reads a lot nicer.

So here's what I came up with, it's a proof of concept that allows you to decide which table function values can be called like a flat value property.

Here's a more thorough example:
```lua
require("callable_properties")

local myNewTable = {}
function myNewTable:getTime()
    return CurTime()
end

myNewTable.time = function(self) return self:getTime() end
CallableProperties.register(myNewTable, "time")
print(myNewTable.time) -- 8001.9575195313

CallableProperties.deregister(myNewTable, "time")
print(myNewTable.time) -- function: 0x020258eb35c0
```

This was my first intro into deep meta table modification, so not only is this solution very poor, it's entirely possible that there's a much easier way to do this (or maybe a way to do this that doesn't require an extra module). Either way, I had fun :)